### PR TITLE
Restructure The Package

### DIFF
--- a/src/AbstractDatabaseModel.php
+++ b/src/AbstractDatabaseModel.php
@@ -14,7 +14,7 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Framework Database Model Class
  *
- * @since  1.0
+ * @since       1.0
  * @deprecated  2.0  Implement the model interfaces directly; the concrete implementations are provided as traits
  */
 abstract class AbstractDatabaseModel extends AbstractModel implements DatabaseModelInterface

--- a/src/AbstractDatabaseModel.php
+++ b/src/AbstractDatabaseModel.php
@@ -16,7 +16,7 @@ use Joomla\Registry\Registry;
  *
  * @since  1.0
  */
-abstract class AbstractDatabaseModel extends AbstractModel
+abstract class AbstractDatabaseModel extends AbstractModel implements DatabaseModelInterface
 {
 	/**
 	 * The database driver.

--- a/src/AbstractModel.php
+++ b/src/AbstractModel.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Framework Base Model Class
  *
- * @since  1.0
+ * @since       1.0
  * @deprecated  2.0  Implement the model interfaces directly; the concrete implementations are provided as traits
  */
 class AbstractModel implements ModelInterface

--- a/src/DatabaseModelInterface.php
+++ b/src/DatabaseModelInterface.php
@@ -26,15 +26,4 @@ interface DatabaseModelInterface
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getDb();
-
-	/**
-	 * Set the database driver.
-	 *
-	 * @param   DatabaseDriver  $db  The database driver.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function setDb(DatabaseDriver $db);
 }

--- a/src/DatabaseModelInterface.php
+++ b/src/DatabaseModelInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Part of the Joomla Framework Model Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Model;
+
+use Joomla\Database\DatabaseDriver;
+
+/**
+ * Joomla Framework Database Model Interface
+ *
+ * @since  __DEPLOY_VERSION__
+ * @note   As of 2.0 the `Joomla\Database\DatabaseInterface` will be typehinted.
+ */
+interface DatabaseModelInterface
+{
+	/**
+	 * Get the database driver.
+	 *
+	 * @return  DatabaseDriver  The database driver.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getDb();
+
+	/**
+	 * Set the database driver.
+	 *
+	 * @param   DatabaseDriver  $db  The database driver.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setDb(DatabaseDriver $db);
+}

--- a/src/DatabaseModelTrait.php
+++ b/src/DatabaseModelTrait.php
@@ -14,6 +14,7 @@ use Joomla\Database\DatabaseDriver;
  * Trait representing a model holding a database reference
  *
  * @since  __DEPLOY_VERSION__
+ * @note   As of 2.0 the `Joomla\Database\DatabaseInterface` will be typehinted.
  */
 trait DatabaseModelTrait
 {

--- a/src/DatabaseModelTrait.php
+++ b/src/DatabaseModelTrait.php
@@ -9,49 +9,38 @@
 namespace Joomla\Model;
 
 use Joomla\Database\DatabaseDriver;
-use Joomla\Registry\Registry;
 
 /**
- * Joomla Framework Database Model Class
+ * Trait representing a model holding a database reference
  *
- * @since  1.0
- * @deprecated  2.0  Implement the model interfaces directly; the concrete implementations are provided as traits
+ * @since  __DEPLOY_VERSION__
  */
-abstract class AbstractDatabaseModel extends AbstractModel implements DatabaseModelInterface
+trait DatabaseModelTrait
 {
 	/**
 	 * The database driver.
 	 *
 	 * @var    DatabaseDriver
-	 * @since  1.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $db;
-
-	/**
-	 * Instantiate the model.
-	 *
-	 * @param   DatabaseDriver  $db     The database adapter.
-	 * @param   Registry        $state  The model state.
-	 *
-	 * @since   1.0
-	 */
-	public function __construct(DatabaseDriver $db, Registry $state = null)
-	{
-		$this->db = $db;
-
-		parent::__construct($state);
-	}
 
 	/**
 	 * Get the database driver.
 	 *
 	 * @return  DatabaseDriver  The database driver.
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  \UnexpectedValueException
 	 */
 	public function getDb()
 	{
-		return $this->db;
+		if ($this->db)
+		{
+			return $this->db;
+		}
+
+		throw new \UnexpectedValueException('Database driver not set in ' . __CLASS__);
 	}
 
 	/**
@@ -61,7 +50,7 @@ abstract class AbstractDatabaseModel extends AbstractModel implements DatabaseMo
 	 *
 	 * @return  void
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setDb(DatabaseDriver $db)
 	{

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\Model;
 
+use Joomla\Registry\Registry;
+
 /**
  * Joomla Framework Model Interface
  *

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -8,32 +8,12 @@
 
 namespace Joomla\Model;
 
-use Joomla\Registry\Registry;
-
 /**
  * Joomla Framework Model Interface
  *
  * @since  1.0
+ * @deprecated  2.0  Use the StatefulModelInterface instead
  */
-interface ModelInterface
+interface ModelInterface extends StatefulModelInterface
 {
-	/**
-	 * Get the model state.
-	 *
-	 * @return  Registry  The state object.
-	 *
-	 * @since   1.0
-	 */
-	public function getState();
-
-	/**
-	 * Set the model state.
-	 *
-	 * @param   Registry  $state  The state object.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.0
-	 */
-	public function setState(Registry $state);
 }

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -13,7 +13,7 @@ use Joomla\Registry\Registry;
 /**
  * Joomla Framework Model Interface
  *
- * @since  1.0
+ * @since       1.0
  * @deprecated  2.0  Use the StatefulModelInterface instead
  */
 interface ModelInterface extends StatefulModelInterface

--- a/src/ModelInterface.php
+++ b/src/ModelInterface.php
@@ -16,4 +16,14 @@ namespace Joomla\Model;
  */
 interface ModelInterface extends StatefulModelInterface
 {
+	/**
+	 * Set the model state.
+	 *
+	 * @param   Registry  $state  The state object.
+	 *
+	 * @return  void
+	 *
+	 * @since   1.0
+	 */
+	public function setState(Registry $state);
 }

--- a/src/StatefulModelInterface.php
+++ b/src/StatefulModelInterface.php
@@ -25,15 +25,4 @@ interface StatefulModelInterface
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getState();
-
-	/**
-	 * Set the model state.
-	 *
-	 * @param   Registry  $state  The state object.
-	 *
-	 * @return  void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function setState(Registry $state);
 }

--- a/src/StatefulModelInterface.php
+++ b/src/StatefulModelInterface.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Part of the Joomla Framework Model Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Model;
+
+use Joomla\Registry\Registry;
+
+/**
+ * Joomla Framework Stateful Model Interface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface StatefulModelInterface
+{
+	/**
+	 * Get the model state.
+	 *
+	 * @return  Registry  The state object.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getState();
+
+	/**
+	 * Set the model state.
+	 *
+	 * @param   Registry  $state  The state object.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function setState(Registry $state);
+}

--- a/src/StatefulModelTrait.php
+++ b/src/StatefulModelTrait.php
@@ -31,10 +31,16 @@ trait StatefulModelTrait
 	 * @return  Registry  The state object.
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  \UnexpectedValueException
 	 */
 	public function getState()
 	{
-		return $this->state;
+		if ($this->state)
+		{
+			return $this->state;
+		}
+
+		throw new \UnexpectedValueException('State not set in ' . __CLASS__);
 	}
 
 	/**

--- a/src/StatefulModelTrait.php
+++ b/src/StatefulModelTrait.php
@@ -11,39 +11,26 @@ namespace Joomla\Model;
 use Joomla\Registry\Registry;
 
 /**
- * Joomla Framework Base Model Class
+ * Trait representing a model holding a state
  *
- * @since  1.0
- * @deprecated  2.0  Implement the model interfaces directly; the concrete implementations are provided as traits
+ * @since  __DEPLOY_VERSION__
  */
-class AbstractModel implements ModelInterface
+trait StatefulModelTrait
 {
 	/**
 	 * The model state.
 	 *
 	 * @var    Registry
-	 * @since  1.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $state;
-
-	/**
-	 * Instantiate the model.
-	 *
-	 * @param   Registry  $state  The model state.
-	 *
-	 * @since   1.0
-	 */
-	public function __construct(Registry $state = null)
-	{
-		$this->state = ($state instanceof Registry) ? $state : new Registry;
-	}
 
 	/**
 	 * Get the model state.
 	 *
 	 * @return  Registry  The state object.
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getState()
 	{
@@ -57,7 +44,7 @@ class AbstractModel implements ModelInterface
 	 *
 	 * @return  void
 	 *
-	 * @since   1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function setState(Registry $state)
 	{


### PR DESCRIPTION
### Summary of Changes

The package currently ships abstract classes that aren't largely useful on their own and forces a structure where all models are stateful.  I propose to restructure things a bit.

First, I introduce two new interfaces, `DatabaseModelInterface` and `StatefulModelInterface` which define models which are aware of our database driver or hold a state.  These interfaces only define getters for their data sources.

Second, I have deprecated the existing `ModelInterface`, models should implement the interfaces they need if desired.  The setter for the state remains in this deprecated interface.

Third, I have deprecated the abstract classes.  They don't provide anything useful on their own.

Fourth, I have created traits for the new interfaces which defines an implementation for the getters, a class property for the data, and setters for optional dependency injection not using a constructor.

The end result is the 2.0 package will only contain the two new interfaces and the traits.